### PR TITLE
feat: Add render-build.sh for chrome browser configuration for production and health check endpoint

### DIFF
--- a/backend/render-build.sh
+++ b/backend/render-build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -o errexit
+
+# Install dependencies
+npm install
+
+# Set cache directory for puppeteer within project
+export PUPPETEER_CACHE_DIR="$PWD/.cache/puppeteer"
+
+# Install Chrome browser for Puppeteer
+npx puppeteer browsers install chrome
+
+# Verify Chrome was installed
+echo "Chrome installed at: $PUPPETEER_CACHE_DIR"
+ls -la .cache/puppeteer/ || echo "Cache directory listing failed"

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -45,6 +45,17 @@ app.use(
 // Passport middleware
 app.use(passport.initialize());
 
+// Health Check
+app.get('/health', (req, res) => {
+    return res.status(200).json({
+        status: "UP",
+        timestamp: new Date().toISOString(),
+        uptime: process.uptime(),
+        environment: process.env.NODE_ENV || "development",
+        message: "Service is healthy"
+    });
+});
+
 // Routes
 app.use('/api/auth', AuthRouter);
 app.use('/api/analyze', AnalyzeRouter);


### PR DESCRIPTION
# 📌 Pull Request

## 📝 Description
<!-- Clearly describe what this PR does -->
- **What problem does it solve?**  
  This PR prepares the backend for deployment (specifically on platforms like Render) where installing system-level dependencies for Puppeteer (like Chrome/Chromium) is required. It also introduces a standard health check endpoint to easily monitor the deployment status and uptime.
- **What feature/change is introduced?**  
  - Added `render-build.sh` in the `backend` directory to properly install Puppeteer browser environments and handle caching during deployment builds.
  - Added a `/health` endpoint in `app.js` to return the service's current status, uptime, environment, and a timestamp for deployment monitoring.

## ✅ Type of Change
<!-- Mark the relevant option(s) -->
- [ ] Bug fix 🐛
- [x] New feature ✨
- [ ] Breaking change ⚠️
- [ ] Refactor 🔨
- [ ] Documentation update 📚
- [ ] Performance improvement 🚀
- [ ] Test update 🧪

## 🧪 How Has This Been Tested?
<!-- Describe tests you ran -->
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Not tested (explain why)

**Test Details:**
- Environment: Local testing and deployment staging context.
- Test cases: Verified that the `/health` endpoint correctly returns a 200 OK with system uptime and environment information. Validated the `render-build.sh` script executes correctly to fetch the Chromium binary for Puppeteer.

## 📋 Checklist
<!-- Ensure all are checked before requesting review -->
- [x] My code follows the project’s coding standards
- [x] I have performed a self-review
- [x] I have commented my code where necessary
- [ ] I have updated the documentation (if needed)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests passed

## ⚠️ Breaking Changes
<!-- Mention any breaking changes and migration steps -->
- None

## 💬 Additional Notes
<!-- Any extra context or information for reviewers -->
Make sure that when deploying to Render or similar platforms, the build command is configured to point to `./render-build.sh` (or `cd backend && ./render-build.sh` depending on root path) and that the `PUPPETEER_CACHE_DIR` environment variable is correctly set in the dashboard if necessary.
